### PR TITLE
Adjust icon positioning for landscape mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -167,7 +167,10 @@ body {
 }
 
 /* Responsive design */
-@media (max-width: 768px) {
+/* More aggressive mobile detection - move controls to header on any mobile device */
+@media (max-width: 1024px) and (orientation: landscape), 
+       (max-width: 768px),
+       (hover: none) and (pointer: coarse) {
     .game-container {
         padding: 4px;
     }
@@ -212,6 +215,34 @@ body {
     .grid-4-cols { grid-template-columns: repeat(3, 1fr); max-width: 480px; }
     .grid-5-cols { grid-template-columns: repeat(4, 1fr); max-width: 635px; }
     .grid-6-cols { grid-template-columns: repeat(4, 1fr); max-width: 635px; }
+}
+
+/* Additional rule specifically for landscape mobile devices */
+@media (max-width: 1024px) and (orientation: landscape) {
+    .controls {
+        /* Ensure controls are always in header for landscape mobile */
+        position: static !important;
+        flex-direction: row;
+        gap: 8px;
+        bottom: auto;
+        right: auto;
+    }
+}
+
+/* Catch-all rule for touch devices to ensure controls are in header */
+@media (hover: none) and (pointer: coarse) {
+    .controls {
+        /* Force controls to header on any touch device */
+        position: static !important;
+        flex-direction: row;
+        gap: 8px;
+        bottom: auto;
+        right: auto;
+    }
+    
+    .game-header {
+        justify-content: space-between;
+    }
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Make mobile button positioning more aggressive to ensure buttons appear in the upper-right header on iOS landscape and other touch devices.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous media query `(max-width: 768px)` did not consistently move controls to the header on iOS devices in landscape mode, as their width can exceed this breakpoint. This PR expands the mobile detection to include landscape orientation up to 1024px width and general touch device detection, ensuring controls are always positioned in the upper-right header on mobile.