### PR TITLE
Add system dark mode support

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -11,6 +11,7 @@
 
 html {
   -webkit-tap-highlight-color: transparent;
+  color-scheme: light dark;
 }
 
 /* Padding helpers that respect safe areas */

--- a/app/javascript/components/App.tsx
+++ b/app/javascript/components/App.tsx
@@ -49,7 +49,7 @@ const App: React.FC = () => {
   }
 
   return (
-    <div className="min-h-dvh bg-neutral-100 text-neutral-900 antialiased">
+    <div className="min-h-dvh bg-neutral-100 text-neutral-900 antialiased dark:bg-neutral-950 dark:text-neutral-100">
       <Header mode={mode} onSwitchMode={switchMode} othersOnline={othersOnline} />
       {mode === 'solo' ? <SolitaireGame /> : <MultiplayerGame />}
     </div>

--- a/app/javascript/components/Board.tsx
+++ b/app/javascript/components/Board.tsx
@@ -28,7 +28,7 @@ const Board: React.FC<BoardProps> = ({
       {/* Round over overlay */}
       {gameOver && (
         <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center">
-          <div className="rounded-full border border-neutral-200 bg-white/95 px-5 py-2 text-sm font-semibold text-neutral-900 shadow-sm">
+          <div className="rounded-full border border-neutral-200 bg-white/95 px-5 py-2 text-sm font-semibold text-neutral-900 shadow-sm dark:border-neutral-700 dark:bg-neutral-900/95 dark:text-neutral-100">
             Round over
           </div>
         </div>
@@ -36,8 +36,8 @@ const Board: React.FC<BoardProps> = ({
 
       {/* Paused overlay hides the board and blocks interaction */}
       {paused && !gameOver && (
-        <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-neutral-100/70 backdrop-blur-md">
-          <div className="rounded-full border border-neutral-200 bg-white/95 px-5 py-2 text-sm font-semibold text-neutral-900 shadow-sm">
+        <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-neutral-100/70 backdrop-blur-md dark:bg-neutral-950/70">
+          <div className="rounded-full border border-neutral-200 bg-white/95 px-5 py-2 text-sm font-semibold text-neutral-900 shadow-sm dark:border-neutral-700 dark:bg-neutral-900/95 dark:text-neutral-100">
             Paused
           </div>
         </div>
@@ -53,8 +53,8 @@ const Board: React.FC<BoardProps> = ({
           const borderStyle = isRejected
             ? 'border-rose-500 ring-2 ring-rose-500/30 animate-shake'
             : isSelected
-              ? 'border-neutral-900 ring-2 ring-neutral-900/15 -translate-y-0.5 shadow-md'
-              : 'border-neutral-200 hover:border-neutral-300'
+              ? 'border-neutral-900 ring-2 ring-neutral-900/15 -translate-y-0.5 shadow-md dark:border-neutral-100 dark:ring-neutral-100/15'
+              : 'border-neutral-200 hover:border-neutral-300 dark:border-neutral-700 dark:hover:border-neutral-600'
 
           return (
             <button
@@ -63,7 +63,7 @@ const Board: React.FC<BoardProps> = ({
               disabled={interactionLocked}
               aria-pressed={isSelected}
               onClick={() => onCardClick(cardId)}
-              className={`animate-card-in block w-full touch-manipulation select-none overflow-hidden rounded-xl border-2 bg-white transition-[border-color,box-shadow,transform] duration-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900 ${
+              className={`animate-card-in block w-full touch-manipulation select-none overflow-hidden rounded-xl border-2 bg-white transition-[border-color,box-shadow,transform] duration-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900 dark:bg-neutral-900 dark:focus-visible:outline-neutral-100 ${
                 interactionLocked ? 'cursor-default' : 'cursor-pointer active:scale-[0.98]'
               } ${borderStyle}`}
             >

--- a/app/javascript/components/Header.tsx
+++ b/app/javascript/components/Header.tsx
@@ -23,15 +23,15 @@ const Header: React.FC<HeaderProps> = ({ mode, onSwitchMode, othersOnline = 0 })
         title={showJewel ? jewelTitle : undefined}
         className={`relative rounded-full px-3.5 py-1.5 text-sm transition-colors ${
           isActive
-            ? 'bg-white font-medium text-neutral-900 shadow-sm'
-            : 'text-neutral-500 hover:text-neutral-800'
+            ? 'bg-white font-medium text-neutral-900 shadow-sm dark:bg-neutral-700 dark:text-neutral-100'
+            : 'text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200'
         }`}
       >
         {label}
         {showJewel && (
           <span className="absolute -right-0.5 -top-0.5 flex h-2.5 w-2.5">
             <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-60" aria-hidden="true" />
-            <span className="relative inline-flex h-2.5 w-2.5 rotate-45 rounded-[3px] bg-emerald-500 shadow-sm ring-1 ring-white" aria-hidden="true" />
+            <span className="relative inline-flex h-2.5 w-2.5 rotate-45 rounded-[3px] bg-emerald-500 shadow-sm ring-1 ring-white dark:ring-neutral-900" aria-hidden="true" />
             <span className="sr-only">{jewelTitle}</span>
           </span>
         )}
@@ -40,7 +40,7 @@ const Header: React.FC<HeaderProps> = ({ mode, onSwitchMode, othersOnline = 0 })
   }
 
   return (
-    <header className="sticky top-0 z-30 border-b border-neutral-200/80 bg-white/85 backdrop-blur">
+    <header className="sticky top-0 z-30 border-b border-neutral-200/80 bg-white/85 backdrop-blur dark:border-neutral-800/80 dark:bg-neutral-900/85">
       <div className="mx-auto flex h-14 w-full max-w-screen-2xl items-center justify-between px-4 md:px-8">
         <div className="flex items-center gap-2.5">
           <span className="text-lg font-semibold tracking-tight">Set</span>
@@ -51,7 +51,7 @@ const Header: React.FC<HeaderProps> = ({ mode, onSwitchMode, othersOnline = 0 })
           </span>
         </div>
 
-        <nav aria-label="Game mode" className="flex items-center rounded-full bg-neutral-200/70 p-1">
+        <nav aria-label="Game mode" className="flex items-center rounded-full bg-neutral-200/70 p-1 dark:bg-neutral-800/70">
           {segment('solo', 'Solo')}
           {segment('multiplayer', 'Multiplayer')}
         </nav>

--- a/app/javascript/components/Scoreboard.tsx
+++ b/app/javascript/components/Scoreboard.tsx
@@ -28,7 +28,7 @@ interface ScoreboardProps {
 }
 
 const SectionLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <div className="text-xs font-medium uppercase tracking-wide text-neutral-400">{children}</div>
+  <div className="text-xs font-medium uppercase tracking-wide text-neutral-400 dark:text-neutral-500">{children}</div>
 )
 
 const Scoreboard: React.FC<ScoreboardProps> = ({
@@ -79,11 +79,11 @@ const Scoreboard: React.FC<ScoreboardProps> = ({
   const isRoundOver = status !== 'playing'
 
   return (
-    <div className="rounded-2xl border border-neutral-200 bg-white p-4 md:p-5">
+    <div className="rounded-2xl border border-neutral-200 bg-white p-4 md:p-5 dark:border-neutral-800 dark:bg-neutral-900">
       {/* Players */}
       <div className="mb-2 flex items-center justify-between">
         <SectionLabel>Players</SectionLabel>
-        <span className="flex items-center gap-1.5 text-xs text-neutral-400">
+        <span className="flex items-center gap-1.5 text-xs text-neutral-400 dark:text-neutral-500">
           <span
             className={`h-1.5 w-1.5 rounded-full ${isConnected ? 'bg-emerald-500' : 'bg-rose-500'}`}
           />
@@ -92,7 +92,7 @@ const Scoreboard: React.FC<ScoreboardProps> = ({
       </div>
 
       {sortedPlayers.length === 0 ? (
-        <div className="py-2 text-sm text-neutral-400">Waiting for players…</div>
+        <div className="py-2 text-sm text-neutral-400 dark:text-neutral-500">Waiting for players…</div>
       ) : (
         <ul className="space-y-1">
           {sortedPlayers.map(({ pid, score }) => {
@@ -102,7 +102,7 @@ const Scoreboard: React.FC<ScoreboardProps> = ({
               <li
                 key={pid}
                 className={`flex items-center justify-between gap-2 rounded-lg px-2.5 py-2 ${
-                  isYou ? 'bg-neutral-100' : ''
+                  isYou ? 'bg-neutral-100 dark:bg-neutral-800' : ''
                 }`}
               >
                 <div className="flex min-w-0 items-center gap-1.5">
@@ -118,14 +118,16 @@ const Scoreboard: React.FC<ScoreboardProps> = ({
                       }}
                       placeholder="Your name"
                       maxLength={20}
-                      className="w-full rounded-md border border-neutral-300 bg-white px-2 py-0.5 text-sm focus:border-neutral-500 focus:outline-none"
+                      className="w-full rounded-md border border-neutral-300 bg-white px-2 py-0.5 text-sm focus:border-neutral-500 focus:outline-none dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100 dark:focus:border-neutral-400"
                     />
                   ) : (
                     <button
                       type="button"
                       onClick={isYou ? startEditing : undefined}
                       className={`group flex min-w-0 items-center gap-1.5 text-sm ${
-                        isYou ? 'cursor-pointer font-medium text-neutral-900' : 'cursor-default text-neutral-700'
+                        isYou
+                          ? 'cursor-pointer font-medium text-neutral-900 dark:text-neutral-100'
+                          : 'cursor-default text-neutral-700 dark:text-neutral-300'
                       }`}
                       title={isYou ? 'Click to edit your name' : undefined}
                     >
@@ -152,7 +154,7 @@ const Scoreboard: React.FC<ScoreboardProps> = ({
                     </button>
                   )}
                 </div>
-                <span className="text-base font-semibold tabular-nums text-neutral-900">{score}</span>
+                <span className="text-base font-semibold tabular-nums text-neutral-900 dark:text-neutral-100">{score}</span>
               </li>
             )
           })}
@@ -160,13 +162,15 @@ const Scoreboard: React.FC<ScoreboardProps> = ({
       )}
 
       {/* Deck and status */}
-      <div className="mt-4 flex items-center justify-between border-t border-neutral-100 pt-3 text-sm">
-        <span className="text-neutral-500">
-          <span className="font-semibold tabular-nums text-neutral-900">{deckCount}</span> cards left
+      <div className="mt-4 flex items-center justify-between border-t border-neutral-100 pt-3 text-sm dark:border-neutral-800">
+        <span className="text-neutral-500 dark:text-neutral-400">
+          <span className="font-semibold tabular-nums text-neutral-900 dark:text-neutral-100">{deckCount}</span> cards left
         </span>
         <span
           className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${
-            isRoundOver ? 'bg-amber-100 text-amber-800' : 'bg-emerald-100 text-emerald-800'
+            isRoundOver
+              ? 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-200'
+              : 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-200'
           }`}
         >
           {isRoundOver ? 'Round over' : 'In play'}
@@ -175,7 +179,7 @@ const Scoreboard: React.FC<ScoreboardProps> = ({
 
       {/* Round results */}
       {isRoundOver && (
-        <div className="mt-3 space-y-2 rounded-xl bg-neutral-50 p-3">
+        <div className="mt-3 space-y-2 rounded-xl bg-neutral-50 p-3 dark:bg-neutral-800/50">
           {placements.length > 0 && (
             <ol className="space-y-1 text-sm">
               {placements.map(p => (
@@ -189,7 +193,7 @@ const Scoreboard: React.FC<ScoreboardProps> = ({
               ))}
             </ol>
           )}
-          <div className="text-sm text-neutral-600">
+          <div className="text-sm text-neutral-600 dark:text-neutral-400">
             Next round in <span className="font-semibold tabular-nums">{Math.max(0, countdown)}</span>…
           </div>
         </div>
@@ -197,7 +201,7 @@ const Scoreboard: React.FC<ScoreboardProps> = ({
 
       {/* Recent sets */}
       {recentClaims.length > 0 && (
-        <div className="mt-4 border-t border-neutral-100 pt-3">
+        <div className="mt-4 border-t border-neutral-100 pt-3 dark:border-neutral-800">
           <SectionLabel>Last sets found</SectionLabel>
           <ul className="mt-2 max-h-72 space-y-2 overflow-y-auto">
             {recentClaims.map((claim, index) => (
@@ -209,11 +213,11 @@ const Scoreboard: React.FC<ScoreboardProps> = ({
                       src={`/cards/${cardId}.png`}
                       alt={`Card ${cardId}`}
                       draggable={false}
-                      className="h-9 w-auto rounded border border-neutral-200 bg-white object-contain md:h-10"
+                      className="h-9 w-auto rounded border border-neutral-200 bg-white object-contain md:h-10 dark:border-neutral-700 dark:bg-neutral-900"
                     />
                   ))}
                 </div>
-                <span className="min-w-0 truncate text-xs text-neutral-500">
+                <span className="min-w-0 truncate text-xs text-neutral-500 dark:text-neutral-400">
                   {names[claim.player_id] || 'Player'}
                 </span>
               </li>

--- a/app/javascript/components/Toast.tsx
+++ b/app/javascript/components/Toast.tsx
@@ -23,7 +23,7 @@ const Toast: React.FC<ToastProps> = ({ message, onClose }) => {
       <button
         type="button"
         onClick={onClose}
-        className="flex items-center gap-2 rounded-full border border-neutral-200 bg-white px-4 py-2 text-sm font-medium text-neutral-800 shadow-lg"
+        className="flex items-center gap-2 rounded-full border border-neutral-200 bg-white px-4 py-2 text-sm font-medium text-neutral-800 shadow-lg dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200"
       >
         <span className={`h-2 w-2 shrink-0 rounded-full ${dotColor}`} aria-hidden="true" />
         {message.text}

--- a/app/javascript/solitaire/SolitaireSidebar.tsx
+++ b/app/javascript/solitaire/SolitaireSidebar.tsx
@@ -23,7 +23,7 @@ interface SolitaireSidebarProps {
 const BEST_TIMES_KEY = 'setgame_solo_best_times'
 
 const SectionLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <div className="text-xs font-medium uppercase tracking-wide text-neutral-400">{children}</div>
+  <div className="text-xs font-medium uppercase tracking-wide text-neutral-400 dark:text-neutral-500">{children}</div>
 )
 
 function formatTime(ms: number): string {
@@ -88,13 +88,13 @@ const SolitaireSidebar: React.FC<SolitaireSidebarProps> = ({
   }, [bestTimes])
 
   const statusChip = isFinished
-    ? { label: 'Finished', classes: 'bg-amber-100 text-amber-800' }
+    ? { label: 'Finished', classes: 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-200' }
     : isPaused
-      ? { label: 'Paused', classes: 'bg-neutral-200 text-neutral-700' }
-      : { label: 'In play', classes: 'bg-emerald-100 text-emerald-800' }
+      ? { label: 'Paused', classes: 'bg-neutral-200 text-neutral-700 dark:bg-neutral-700 dark:text-neutral-200' }
+      : { label: 'In play', classes: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-200' }
 
   return (
-    <div className="rounded-2xl border border-neutral-200 bg-white p-4 md:p-5">
+    <div className="rounded-2xl border border-neutral-200 bg-white p-4 md:p-5 dark:border-neutral-800 dark:bg-neutral-900">
       {/* Timer */}
       <div className="flex items-center justify-between">
         <SectionLabel>Time</SectionLabel>
@@ -103,7 +103,7 @@ const SolitaireSidebar: React.FC<SolitaireSidebarProps> = ({
         </span>
       </div>
       <div className="mt-1 flex items-center justify-between gap-2">
-        <div className="text-4xl font-semibold tabular-nums tracking-tight text-neutral-900">
+        <div className="text-4xl font-semibold tabular-nums tracking-tight text-neutral-900 dark:text-neutral-100">
           {formatTime(elapsedMs)}
         </div>
         <div className="flex items-center gap-1">
@@ -111,7 +111,7 @@ const SolitaireSidebar: React.FC<SolitaireSidebarProps> = ({
             <button
               type="button"
               onClick={onTogglePause}
-              className="rounded-full p-2 text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-700"
+              className="rounded-full p-2 text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-700 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"
               title={isPaused ? 'Resume' : 'Pause'}
               aria-label={isPaused ? 'Resume' : 'Pause'}
             >
@@ -129,7 +129,7 @@ const SolitaireSidebar: React.FC<SolitaireSidebarProps> = ({
           <button
             type="button"
             onClick={onRestart}
-            className="rounded-full p-2 text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-700"
+            className="rounded-full p-2 text-neutral-400 transition-colors hover:bg-neutral-100 hover:text-neutral-700 dark:hover:bg-neutral-800 dark:hover:text-neutral-200"
             title="New game"
             aria-label="New game"
           >
@@ -150,25 +150,25 @@ const SolitaireSidebar: React.FC<SolitaireSidebarProps> = ({
       </div>
 
       {/* Stats */}
-      <div className="mt-4 flex items-center justify-between border-t border-neutral-100 pt-3 text-sm">
-        <span className="text-neutral-500">
-          <span className="font-semibold tabular-nums text-neutral-900">{deckCount}</span> cards left
+      <div className="mt-4 flex items-center justify-between border-t border-neutral-100 pt-3 text-sm dark:border-neutral-800">
+        <span className="text-neutral-500 dark:text-neutral-400">
+          <span className="font-semibold tabular-nums text-neutral-900 dark:text-neutral-100">{deckCount}</span> cards left
         </span>
-        <span className="text-neutral-500">
-          <span className="font-semibold tabular-nums text-neutral-900">{setsFound}</span> sets found
+        <span className="text-neutral-500 dark:text-neutral-400">
+          <span className="font-semibold tabular-nums text-neutral-900 dark:text-neutral-100">{setsFound}</span> sets found
         </span>
       </div>
 
       {/* Finished round summary */}
       {isFinished && (
-        <div className="mt-3 space-y-2 rounded-xl bg-neutral-50 p-3">
-          <div className="text-sm text-neutral-700">
+        <div className="mt-3 space-y-2 rounded-xl bg-neutral-50 p-3 dark:bg-neutral-800/50">
+          <div className="text-sm text-neutral-700 dark:text-neutral-300">
             Cleared the deck in <span className="font-semibold tabular-nums">{formatTime(elapsedMs)}</span>
           </div>
           <button
             type="button"
             onClick={onRestart}
-            className="w-full rounded-lg bg-neutral-900 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-neutral-700"
+            className="w-full rounded-lg bg-neutral-900 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-neutral-700 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-neutral-300"
           >
             Play again
           </button>
@@ -177,7 +177,7 @@ const SolitaireSidebar: React.FC<SolitaireSidebarProps> = ({
 
       {/* Best times */}
       {bestTimes.length > 0 && (
-        <div className="mt-4 border-t border-neutral-100 pt-3">
+        <div className="mt-4 border-t border-neutral-100 pt-3 dark:border-neutral-800">
           <SectionLabel>Best times</SectionLabel>
           <ol className="mt-2 space-y-1">
             {bestTimes.map((entry, index) => {
@@ -187,11 +187,13 @@ const SolitaireSidebar: React.FC<SolitaireSidebarProps> = ({
                 <li
                   key={`${entry.at}-${entry.ms}`}
                   className={`flex items-center justify-between rounded-lg px-2.5 py-1.5 text-sm ${
-                    isNewest ? 'bg-amber-50' : ''
+                    isNewest ? 'bg-amber-50 dark:bg-amber-950/50' : ''
                   }`}
                 >
                   <span className="flex items-center gap-2">
-                    <span className={`tabular-nums ${isBest ? 'font-semibold text-neutral-900' : 'text-neutral-700'}`}>
+                    <span
+                      className={`tabular-nums ${isBest ? 'font-semibold text-neutral-900 dark:text-neutral-100' : 'text-neutral-700 dark:text-neutral-300'}`}
+                    >
                       {formatTime(entry.ms)}
                     </span>
                     {isBest && isNewest && (
@@ -216,7 +218,7 @@ const SolitaireSidebar: React.FC<SolitaireSidebarProps> = ({
 
       {/* Recent sets */}
       {recentClaims.length > 0 && (
-        <div className="mt-4 border-t border-neutral-100 pt-3">
+        <div className="mt-4 border-t border-neutral-100 pt-3 dark:border-neutral-800">
           <SectionLabel>Last sets found</SectionLabel>
           <ul className="mt-2 max-h-72 space-y-2 overflow-y-auto">
             {recentClaims.map((claim, index) => (
@@ -227,7 +229,7 @@ const SolitaireSidebar: React.FC<SolitaireSidebarProps> = ({
                     src={`/cards/${cardId}.png`}
                     alt={`Card ${cardId}`}
                     draggable={false}
-                    className="h-9 w-auto rounded border border-neutral-200 bg-white object-contain md:h-10"
+                    className="h-9 w-auto rounded border border-neutral-200 bg-white object-contain md:h-10 dark:border-neutral-700 dark:bg-neutral-900"
                   />
                 ))}
               </li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,8 @@
   <head>
     <title><%= content_for(:title) || "Set" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
-    <meta name="theme-color" content="#f5f5f5">
+    <meta name="theme-color" content="#f5f5f5" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
@@ -20,7 +21,7 @@
     <%= javascript_include_tag "application", type: "module" %>
   </head>
 
-  <body class="bg-neutral-100">
+  <body class="bg-neutral-100 text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
     <%= yield %>
   </body>
 </html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The app now follows the operating system light/dark preference using Tailwind's default `prefers-color-scheme: dark` behavior (no manual theme toggle).

## Changes

- Added `dark:` utility classes across the React UI (header, board, scoreboards, toasts, sidebars)
- Set `color-scheme: light dark` on `html` so native form controls match the system theme
- Updated layout body styles and `theme-color` meta tags for light and dark system modes

## How to verify

1. Set your OS or browser to dark mode
2. Load the app — background, panels, header, and overlays should use dark neutrals
3. Switch back to light mode — the previous light appearance should return automatically
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98d2aafb-0069-4c84-9fa9-151d05834b9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98d2aafb-0069-4c84-9fa9-151d05834b9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

