### PR TITLE
Fix cloud environment bootstrap and preview dark mode

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -4,7 +4,7 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "install": "bundle config unset deployment 2>/dev/null || true; bundle config unset without 2>/dev/null || true; bundle install && yarn install --check-files && yarn build && yarn build:css",
+  "install": "./script/bootstrap-dev.sh",
   "ports": [
     {
       "name": "Rails",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes the Set Game app runnable on default Cursor Cloud VMs (Node-only image) and keeps the system dark mode preview branch current.

## Changes

- **`.cursor/environment.json`**: Run `./script/bootstrap-dev.sh` during `install` instead of assuming Ruby is already present. Default cloud images do not include Ruby; the bootstrap script installs Ruby via apt when needed, then runs `bundle install`, `yarn install`, and asset builds.

## Verification

- `./script/bootstrap-dev.sh` completed successfully on a fresh VM
- `bin/dev` listening on port 3000 (`curl` returns `200` for `/`)
- Built CSS includes `prefers-color-scheme: dark` rules for Tailwind `dark:` variants

## Notes

Dark mode commit (`0a14b3d`) is already on `main`; this branch adds the cloud install fix on top of latest `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1368ab3e-f612-45dc-bbc1-3f4f2d9b8b55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1368ab3e-f612-45dc-bbc1-3f4f2d9b8b55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

