### PR TITLE
Fix gray halos on cards in dark mode

### DIFF
--- a/app/javascript/components/Board.tsx
+++ b/app/javascript/components/Board.tsx
@@ -63,7 +63,7 @@ const Board: React.FC<BoardProps> = ({
               disabled={interactionLocked}
               aria-pressed={isSelected}
               onClick={() => onCardClick(cardId)}
-              className={`animate-card-in block w-full touch-manipulation select-none overflow-hidden rounded-xl border-2 bg-white transition-[border-color,box-shadow,transform] duration-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900 dark:bg-neutral-900 dark:focus-visible:outline-neutral-100 ${
+              className={`animate-card-in block w-full touch-manipulation select-none overflow-hidden rounded-xl border-2 bg-white transition-[border-color,box-shadow,transform] duration-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900 dark:bg-white dark:focus-visible:outline-neutral-100 ${
                 interactionLocked ? 'cursor-default' : 'cursor-pointer active:scale-[0.98]'
               } ${borderStyle}`}
             >
@@ -73,7 +73,7 @@ const Board: React.FC<BoardProps> = ({
                 loading="eager"
                 decoding="async"
                 draggable={false}
-                className="pointer-events-none aspect-[258/167] w-full object-contain"
+                className="pointer-events-none aspect-[258/167] w-full bg-white object-contain"
               />
             </button>
           )

--- a/app/javascript/components/Scoreboard.tsx
+++ b/app/javascript/components/Scoreboard.tsx
@@ -213,7 +213,7 @@ const Scoreboard: React.FC<ScoreboardProps> = ({
                       src={`/cards/${cardId}.png`}
                       alt={`Card ${cardId}`}
                       draggable={false}
-                      className="h-9 w-auto rounded border border-neutral-200 bg-white object-contain md:h-10 dark:border-neutral-700 dark:bg-neutral-900"
+                      className="h-9 w-auto rounded border border-neutral-200 bg-white object-contain md:h-10 dark:border-neutral-700 dark:bg-white"
                     />
                   ))}
                 </div>

--- a/app/javascript/solitaire/SolitaireSidebar.tsx
+++ b/app/javascript/solitaire/SolitaireSidebar.tsx
@@ -229,7 +229,7 @@ const SolitaireSidebar: React.FC<SolitaireSidebarProps> = ({
                     src={`/cards/${cardId}.png`}
                     alt={`Card ${cardId}`}
                     draggable={false}
-                    className="h-9 w-auto rounded border border-neutral-200 bg-white object-contain md:h-10 dark:border-neutral-700 dark:bg-neutral-900"
+                    className="h-9 w-auto rounded border border-neutral-200 bg-white object-contain md:h-10 dark:border-neutral-700 dark:bg-white"
                   />
                 ))}
               </li>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In dark mode, faint gray outlines appeared around symbols on some cards.

## Cause

Not bad image files — the PNGs look correct on white. Dark mode set card **tile backgrounds** to `neutral-900`. Anti-aliased edge pixels in the images are slightly transparent and composite against whatever is behind them; on a dark tile that reads as gray halos. On white (light mode) they are invisible.

## Fix

CSS only — keep card tiles and thumbnails white in dark mode (`dark:bg-white`, `bg-white` on board images), matching physical Set cards.

## No asset changes

Reverted re-encoding of `public/cards/*.png`; originals are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1368ab3e-f612-45dc-bbc1-3f4f2d9b8b55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1368ab3e-f612-45dc-bbc1-3f4f2d9b8b55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

