### PR TITLE
Start a fresh solo game when resuming after 15+ minutes idle

### DIFF
--- a/app/javascript/solitaire/SolitaireGame.tsx
+++ b/app/javascript/solitaire/SolitaireGame.tsx
@@ -22,6 +22,10 @@ import {
 
 const LOCAL_STORAGE_KEY = 'setgame_solo_state_v2'
 const BEST_TIMES_KEY = 'setgame_solo_best_times'
+// Discard an in-progress solo game once the player has been away this long.
+const IDLE_RESET_MS = 15 * 60 * 1000
+// While playing with the tab visible, refresh the saved activity stamp this often.
+const ACTIVITY_SAVE_INTERVAL_MS = 10_000
 
 interface RecentClaim {
   cards: number[]
@@ -41,6 +45,8 @@ type SavedSoloState = {
   rngState: number
   events: ClaimEvent[]
   eligible: boolean
+  // Wall-clock time of the last save (i.e. last meaningful activity).
+  savedAtMs: number
 }
 
 function loadSavedGame(): SavedSoloState | null {
@@ -64,16 +70,25 @@ function loadSavedGame(): SavedSoloState | null {
       events: Array.isArray(parsed.events) ? parsed.events : [],
       eligible: Boolean(parsed.eligible && parsed.gameId),
       rngState: typeof parsed.rngState === 'number' ? parsed.rngState : 0,
-      gameId: parsed.gameId || null
+      gameId: parsed.gameId || null,
+      // Older saves have no savedAtMs; approximate last activity from the
+      // timer values that were current when the save was written.
+      savedAtMs:
+        typeof parsed.savedAtMs === 'number'
+          ? parsed.savedAtMs
+          : parsed.startedAtMs + Math.max(0, parsed.elapsedMs)
     }
   } catch {
     return null
   }
 }
 
-function saveGame(state: SavedSoloState): void {
+function saveGame(state: Omit<SavedSoloState, 'savedAtMs'>): void {
   try {
-    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(state))
+    localStorage.setItem(
+      LOCAL_STORAGE_KEY,
+      JSON.stringify({ ...state, savedAtMs: Date.now() })
+    )
   } catch {
     // Ignore storage failures
   }
@@ -112,6 +127,14 @@ const SolitaireGame: React.FC = () => {
   const gameIdRef = useRef<string | null>(null)
   const seedRef = useRef(0)
   const submittedRef = useRef(false)
+  const recentClaimsRef = useRef<RecentClaim[]>([])
+  // Wall-clock time of the last meaningful activity (save or visible timer tick).
+  const lastActivityAtRef = useRef(Date.now())
+  const lastActivitySaveRef = useRef(0)
+
+  useEffect(() => {
+    recentClaimsRef.current = recentClaims
+  }, [recentClaims])
 
   const showToast = (text: string, type: ToastType = 'success') => {
     if (toastTimeoutRef.current) clearTimeout(toastTimeoutRef.current)
@@ -151,6 +174,7 @@ const SolitaireGame: React.FC = () => {
       events: opts.events,
       eligible: opts.eligible
     })
+    lastActivityAtRef.current = Date.now()
   }
 
   const applyDeal = (
@@ -234,6 +258,13 @@ const SolitaireGame: React.FC = () => {
       events: []
     })
     showToast("Offline — won't count for leaderboard", 'error')
+  }
+
+  const startFreshAfterIdle = () => {
+    // Stamp activity first so overlapping timer ticks don't re-trigger the reset.
+    lastActivityAtRef.current = Date.now()
+    showToast('New game — previous game was idle for 15+ minutes', 'success')
+    void startNewGame()
   }
 
   const finishGame = async (finalMs: number, claimEvents: ClaimEvent[]) => {
@@ -377,6 +408,10 @@ const SolitaireGame: React.FC = () => {
         })
       }
     } else if (status === 'paused') {
+      if (Date.now() - lastActivityAtRef.current >= IDLE_RESET_MS) {
+        startFreshAfterIdle()
+        return
+      }
       const newStart = Date.now() - elapsedMs
       setStartedAtMs(newStart)
       setStatus('playing')
@@ -398,7 +433,34 @@ const SolitaireGame: React.FC = () => {
   useEffect(() => {
     if (status === 'playing') {
       timerRef.current = setInterval(() => {
-        setElapsedMs(Date.now() - startedAtMs)
+        const now = Date.now()
+        setElapsedMs(now - startedAtMs)
+        if (document.visibilityState !== 'visible') return
+
+        // Returning to a backgrounded tab after a long absence: start fresh.
+        if (now - lastActivityAtRef.current >= IDLE_RESET_MS) {
+          startFreshAfterIdle()
+          return
+        }
+
+        lastActivityAtRef.current = now
+        // Periodically persist so savedAtMs tracks presence, not just moves.
+        if (
+          now - lastActivitySaveRef.current >= ACTIVITY_SAVE_INTERVAL_MS &&
+          dealStateRef.current
+        ) {
+          lastActivitySaveRef.current = now
+          writeSave(dealStateRef.current, {
+            status: 'playing',
+            recentClaims: recentClaimsRef.current,
+            startedAtMs,
+            elapsedMs: now - startedAtMs,
+            gameId: gameIdRef.current,
+            seed: seedRef.current,
+            events: eventsRef.current,
+            eligible: eligibleRef.current
+          })
+        }
       }, 100)
     } else if (timerRef.current) {
       clearInterval(timerRef.current)
@@ -411,7 +473,14 @@ const SolitaireGame: React.FC = () => {
 
   useEffect(() => {
     const saved = loadSavedGame()
-    if (saved && saved.board.length > 0) {
+    const staleInProgress =
+      saved !== null &&
+      saved.status !== 'round_over' &&
+      Date.now() - saved.savedAtMs >= IDLE_RESET_MS
+    if (staleInProgress) {
+      // The player was away 15+ minutes: discard the stale game, deal fresh.
+      startFreshAfterIdle()
+    } else if (saved && saved.board.length > 0) {
       const deal = restoreSoloDeal(saved.board, saved.deck, saved.rngState)
       const wasPaused = saved.status === 'paused'
       applyDeal(deal, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Bug

Solo games persist in `localStorage` (`setgame_solo_state_v2`) and always resumed on load, with elapsed time recomputed as `Date.now() - startedAtMs`. Returning days later produced a stale half-finished board with a timer like `TIME 67248:21`, "In play".

## Fix (solo only, all in `SolitaireGame.tsx`)

- Every save is now stamped with `savedAtMs` (last meaningful activity). While a game is playing with the tab visible, the save is refreshed every 10 seconds, so `savedAtMs` tracks presence rather than just moves — a player pondering the board without moving is not treated as away.
- An in-progress (`playing` or `paused`) game idle for **≥ 15 minutes** is discarded and a new deal starts automatically (same path as the New Game button), with a one-line transient toast. This check runs:
  - on load/mount (tab closed and reopened),
  - on the first visible timer tick after returning to a backgrounded tab (ticks while hidden never refresh the activity stamp),
  - on clicking resume from a pause that sat 15+ minutes.
- Under 15 minutes: resumes exactly as before (board, timer, pause state).
- Legacy saves without `savedAtMs` approximate last activity as `startedAtMs + elapsedMs` (the timer values current at the last write).
- Unchanged: completed games (`round_over` saves restore regardless of age), leaderboard, MY TIMES, and multiplayer `/m`.

## Before / after

Seeded a save whose last activity was ~46h ago, then reloaded:

![Before: stale game resumes with TIME 2760:01](https://cursor.com/artifacts/c/art-12082f31-8f45-48e7-bc4c-84f17b00ecad)
![After: fresh deal, timer 0:01, transient note](https://cursor.com/artifacts/c/art-9675f05c-7830-48fa-9b54-fba81132034e)

## Testing

No JS test runner exists in the repo, so this was verified with a scripted Playwright check against the running app (17 assertions, all passing):

- fresh visit creates a playing save stamped with `savedAtMs`
- playing game idle 20 min → new seed, timer `0:00`, toast shown
- playing game away 5 min → same seed and board, timer continues from `5:00`
- paused game idle 16 min → new deal
- paused game idle 5 min → resumes paused with same seed
- legacy save (no `savedAtMs`) last written 2 days ago → new deal
- completed game from 2 days ago → restored unchanged (`round_over`, Finished chip)

`yarn typecheck` and `yarn build` pass.

### Manual repro steps

1. Open `/`, start playing (make a move or wait ~10s so the save is stamped).
2. In DevTools, edit `localStorage.setgame_solo_state_v2`: set `savedAtMs` to `Date.now() - 16*60*1000` (and optionally `startedAtMs` far in the past).
3. Reload: a new deal appears with the timer near 0 and a "New game — previous game was idle for 15+ minutes" note.
4. Repeat with `savedAtMs` 5 minutes ago: the same board resumes with the timer continuing.

## Note

Each automatic reset opens a new server-side game while the abandoned one stays open until the 7-day `SoloGame.expire_stale!` expiry. A player abandoning 5+ games within 7 days hits `MAX_OPEN_PER_PLAYER` and the new game falls back to offline/ineligible mode — identical to the pre-existing behavior of repeatedly pressing New Game, so the server was left untouched.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85f2eaf2-6a25-41bf-a522-c25925f06eb4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85f2eaf2-6a25-41bf-a522-c25925f06eb4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

